### PR TITLE
Made Greek letter mu be equivalent to micro prefix

### DIFF
--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -115,7 +115,8 @@ siPrefix =
   <|> (string "f" *> pure femto)
   <|> (string "p" *> pure pico)
   <|> (string "n" *> pure nano)
-  <|> (string "µ" *> pure micro)
+  <|> (string "µ" *> pure micro) -- Micro sign U+00B5
+  <|> (string "μ" *> pure micro) -- Greek small letter mu U+039C
   <|> (string "m" *> pure milli)
   <|> (string "c" *> pure centi)
   <|> (string "d" *> pure deci)


### PR DESCRIPTION
Insect already recognizes the micro sign (u+00b5) as the micro prefix, but it should recognize the Greek letter mu (u+03bc) as well. 

[Apparently](https://en.wikipedia.org/wiki/Micro-#Symbol_encoding_in_character_sets), the Unicode Consortium recommends the Greek letter over and on top of the supplementary symbol too:

    Micro sign is included in several  parts  of ISO/IEC 8859, and  therefore  supported in many legacy environments where U+03BC μ is not available. Implementations therefore need to be able to recognize the micro sign, even though U+03BC μ is the preferred character in a Unicode context.

I for one would love support for μ just because I can type it more easily 😺!