### PR TITLE
Parse 'u' as a the SI prefix micro

### DIFF
--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -156,6 +156,7 @@ siPrefixDict = Dictionary
   , Q.pico ==> ["pico", "p"]
   , Q.nano ==> ["nano", "n"]
   , Q.micro ==> [ "micro"
+                , "u" -- u for micro
                 , "µ" -- Micro sign U+00B5
                 , "μ" -- Greek small letter mu U+039C
                 ]


### PR DESCRIPTION
It is very common to use u as the SI prefix for micro since the special symbol `µ` is usually not available on all keyboard. It is also way easier to type.