### PR TITLE
Add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ For Arch Linux, there is a [package on AUR](https://aur.archlinux.org/packages/i
 yaourt -S insect
 ```
 
+For macOS, there is a [Homebrew package](http://braumeister.org/formula/insect):
+```sh
+brew install insect
+```
+
 Development
 -----------
 Insect is written in PureScript (see [Getting Started](https://github.com/purescript/documentation/blob/master/guides/Getting-Started.md) guide). You can install all dependencies and build the whole project by running:


### PR DESCRIPTION
I just added insect to Homebrew (Homebrew/homebrew-core#14928). It would be nice to mention it on README, seeing that the AUR package has also been mentioned.

The link http://braumeister.org/formula/insect isn't live yet at the time of this PR; that's because it takes an hour or two for Braumeister to pick up changes.