### PR TITLE
Run `build` on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "test"
   },
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "bower install && npm run build",
     "start": "pulp -w browserify --skip-entry-point -m Insect --standalone Insect -O -t insect.js",
     "browserify": "pulp browserify --skip-entry-point -m Insect --standalone Insect -O -t insect.js",
     "build": "pulp build -m Insect",


### PR DESCRIPTION
After cloning the repository for the first time, `npm run build` needs to be run once in order to create the following files:

```
web/insect.js
web/jquery.min.js
web/jquery.mousewheel-min.js
web/jquery.terminal.min.js
web/keyboardevent-key-polyfill.js
```

It looks like this was an undocumented necessary step to set up the project.
This PR adds `npm run build` it to the `postinstall` hook to make it run automatically on install.
