### PR TITLE
Add `thou` unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Reference
     | [Tablespoon](https://en.wikipedia.org/wiki/Tablespoon)                       | `tablespoons`, `tablespoon`, `tbsp`                                         |
     | [Teaspoon](https://en.wikipedia.org/wiki/Teaspoon)                           | `teaspoons`, `teaspoon`, `tsp`                                              |
     | [Tesla](https://en.wikipedia.org/wiki/Tesla_(unit))                          | `tesla`, `T`                                                                |
+    | [Thou](https://en.wikipedia.org/wiki/Thousandth_of_an_inch)                  | `thou`                                                                      |
     | [Tonne](https://en.wikipedia.org/wiki/Tonne)                                 | `tonnes`, `tonne`, `tons`, `ton`, `t`                                       |
     | [US Dollar](https://en.wikipedia.org/wiki/USD)                               | `dollars`, `dollar`, `USD`, `$`                                             |
     | [Volt](https://en.wikipedia.org/wiki/Volt)                                   | `volts`, `volt`, `V`                                                        |

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-quantities": "^8.2.0",
+    "purescript-quantities": "^8.3.0",
     "purescript-parsing": "^5.0.0",
     "purescript-ordered-collections": "^1.0.0",
     "jquery.terminal": "=1.6.3",

--- a/docs/reference-units.md
+++ b/docs/reference-units.md
@@ -81,6 +81,7 @@
     | [Tablespoon](https://en.wikipedia.org/wiki/Tablespoon) | `tablespoons`, `tablespoon`, `tbsp` |
     | [Teaspoon](https://en.wikipedia.org/wiki/Teaspoon) | `teaspoons`, `teaspoon`, `tsp` |
     | [Tesla](https://en.wikipedia.org/wiki/Tesla_(unit)) | `tesla`, `T` |
+    | [Thou](https://en.wikipedia.org/wiki/Thousandth_of_an_inch) | `thou` |
     | [Tonne](https://en.wikipedia.org/wiki/Tonne) | `tonnes`, `tonne`, `tons`, `ton`, `t` |
     | [US Dollar](https://en.wikipedia.org/wiki/USD) | `dollars`, `dollar`, `USD`, `$` |
     | [Volt](https://en.wikipedia.org/wiki/Volt) | `volts`, `volt`, `V` |

--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -261,6 +261,7 @@ imperialUnitDict = Dictionary
   , Q.inch ==> ["inches", "inch", "in"]
   , Q.yard ==> ["yards", "yard", "yd"]
   , Q.foot ==> ["feet", "foot", "ft"]
+  , Q.thou ==> ["thou"]
   , Q.ounce ==> ["ounces", "ounce", "oz"]
   , Q.lbf ==> ["pound_force", "lbf"]
   , Q.pound ==> ["pounds", "pound", "lb"]


### PR DESCRIPTION
These come up a lot in PCB design (e.g. track widths are measured in thou)
https://en.wikipedia.org/wiki/Thousandth_of_an_inch

Based on https://github.com/sharkdp/purescript-quantities/pull/38 to add `thou` to purescript-quantities (so I will add a change to package.json to up the version number if that gets merged).