### PR TITLE
Add parts-per-{cent,million,billion,trillion,quadrillion}.

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,12 @@ Reference
     | [Ounce](https://en.wikipedia.org/wiki/Ounce)                                 | `ounces`, `ounce`, `oz`                                                     |
     | [PPI](https://en.wikipedia.org/wiki/Pixels_per_inch)                         | `ppi`                                                                       |
     | [Parsec](https://en.wikipedia.org/wiki/Parsec)                               | `parsecs`, `parsec`, `pc`                                                   |
-    | [Pascal](https://en.wikipedia.org/wiki/Pascal_(unit))                        | `pascal`, `Pa`                                                              |
+    | [Parts-per-million](https://en.wikipedia.org/wiki/Parts-per_notation)        | `ppm` |
+    | [Parts-per-billion](https://en.wikipedia.org/wiki/Parts-per_notation)        | `ppb` |
+    | [Parts-per-trillion](https://en.wikipedia.org/wiki/Parts-per_notation)       | `ppt` |
+    | [Parts-per-quadrillion](https://en.wikipedia.org/wiki/Parts-per_notation)    | `ppq` |
+    | [Pascal](https://en.wikipedia.org/wiki/Pascal_(unit))                        | `pascal`, `Pa` |
+    | [Percent](https://en.wikipedia.org/wiki/Parts-per_notation)                  | `percent`, `pct` |                        | `pascal`, `Pa`                                                              |
     | [Person](https://en.wiktionary.org/wiki/person)                              | `persons`, `person`, `people`                                               |
     | [Piece](https://en.wiktionary.org/wiki/piece)                                | `pieces`, `piece`                                                           |
     | [Pint](https://en.wikipedia.org/wiki/Pint)                                   | `pints`, `pint`                                                             |

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-quantities": "^8.2.0",
+    "purescript-quantities": "^8.3.0",
     "purescript-parsing": "^5.0.0",
     "purescript-ordered-collections": "^1.0.0",
     "jquery.terminal": "=1.6.3",

--- a/docs/reference-units.md
+++ b/docs/reference-units.md
@@ -64,7 +64,12 @@
     | [Ounce](https://en.wikipedia.org/wiki/Ounce) | `ounces`, `ounce`, `oz` |
     | [PPI](https://en.wikipedia.org/wiki/Pixels_per_inch) | `ppi` |
     | [Parsec](https://en.wikipedia.org/wiki/Parsec) | `parsecs`, `parsec`, `pc` |
+    | [Parts-per-million](https://en.wikipedia.org/wiki/Parts-per_notation) | `ppm` |
+    | [Parts-per-billion](https://en.wikipedia.org/wiki/Parts-per_notation) | `ppb` |
+    | [Parts-per-trillion](https://en.wikipedia.org/wiki/Parts-per_notation) | `ppt` |
+    | [Parts-per-quadrillion](https://en.wikipedia.org/wiki/Parts-per_notation) | `ppq` |
     | [Pascal](https://en.wikipedia.org/wiki/Pascal_(unit)) | `pascal`, `Pa` |
+    | [Percent](https://en.wikipedia.org/wiki/Parts-per_notation) | `percent`, `pct` |
     | [Person](https://en.wiktionary.org/wiki/person) | `persons`, `person`, `people` |
     | [Piece](https://en.wiktionary.org/wiki/piece) | `pieces`, `piece` |
     | [Pint](https://en.wikipedia.org/wiki/Pint) | `pints`, `pint` |

--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -256,7 +256,12 @@ normalUnit = buildDictParser normalUnitDict <?> "normal unit"
 -- | Imperial units
 imperialUnitDict ∷ Dictionary DerivedUnit
 imperialUnitDict = Dictionary
-  [ Q.mile ==> ["miles", "mile"]
+  [ Q.percent ==> ["pct", "percent"]
+  , Q.partsPerMillion ==> ["ppm"]
+  , Q.partsPerBillion ==> ["ppb"]
+  , Q.partsPerTrillion ==> ["ppt"]
+  , Q.partsPerQuadrillion ==> ["ppq"]
+  , Q.mile ==> ["miles", "mile"]
   , Q.mile ./ Q.hour ==> ["mph"]
   , Q.inch ==> ["inches", "inch", "in"]
   , Q.yard ==> ["yards", "yard", "yd"]


### PR DESCRIPTION
Based on https://github.com/sharkdp/purescript-quantities/pull/39 to add the relevant units to purescript-quantities (so I will add a change to package.json to up the version number if that gets merged).