### PR TITLE
Perform conversion even if units are equal

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-quantities": "^8.3.0",
+    "purescript-quantities": "^8.3.1",
     "purescript-parsing": "^5.0.0",
     "purescript-ordered-collections": "^1.0.0",
     "jquery.terminal": "=1.6.3",

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -842,6 +842,7 @@ main = runTest do
       expectOutput' "5.08 cm" "2in to cm"
       expectOutput' "500 m·cm" "5m^2 -> m*cm"
       expectOutput' "500 cm·m" "5m^2 -> cm*m"
+      expectOutput' "0.1 MB/s" "1 kB / 10 ms -> MB/s"
 
     test "Implicit multiplication" do
       let myEnv =


### PR DESCRIPTION
Explicitly perform the conversion to the target unit even if the
units are mathematically equal, to ensure that (for example)

    kB / ms

can be converted to

    MB / s

closes #200