### PR TITLE
Add Plural Henry units

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Reference
     | [Gram](https://en.wikipedia.org/wiki/Gram)                                   | `grams`, `gram`, `grammes`, `gramme`, `g`                                   |
     | [Gray](https://en.wikipedia.org/wiki/Gray_(unit))                            | `gray`, `Gy`                                                                |
     | [Hectare](https://en.wikipedia.org/wiki/Hectare)                             | `hectare`, `ha`                                                             |
-    | [Henry](https://en.wikipedia.org/wiki/Henry_(unit))                          | `henry`, `H`                                                                |
+    | [Henry](https://en.wikipedia.org/wiki/Henry_(unit))                          | `henrys`, `henries`, `henry`, `H`                                                                |
     | [Hertz](https://en.wikipedia.org/wiki/Hertz)                                 | `hertz`, `Hz`                                                               |
     | [Hogshead](https://en.wikipedia.org/wiki/Hogshead)                           | `hogsheads`, `hogshead`                                                     |
     | [Hour](https://en.wikipedia.org/wiki/Hour)                                   | `hours`, `hour`, `h`                                                        |

--- a/docs/reference-units.md
+++ b/docs/reference-units.md
@@ -40,7 +40,7 @@
     | [Gram](https://en.wikipedia.org/wiki/Gram) | `grams`, `gram`, `grammes`, `gramme`, `g` |
     | [Gray](https://en.wikipedia.org/wiki/Gray_(unit)) | `gray`, `Gy` |
     | [Hectare](https://en.wikipedia.org/wiki/Hectare) | `hectare`, `ha` |
-    | [Henry](https://en.wikipedia.org/wiki/Henry_(unit)) | `henry`, `H` |
+    | [Henry](https://en.wikipedia.org/wiki/Henry_(unit)) | `henrys`, `henries`, `henry`, `H` |
     | [Hertz](https://en.wikipedia.org/wiki/Hertz) | `hertz`, `Hz` |
     | [Hogshead](https://en.wikipedia.org/wiki/Hogshead) | `hogsheads`, `hogshead` |
     | [Hour](https://en.wikipedia.org/wiki/Hour) | `hours`, `hour`, `h` |

--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -202,7 +202,7 @@ normalUnitDict = Dictionary
   , Q.sievert ==> ["sievert", "Sv"]
   , Q.weber ==> ["weber", "Wb"]
   , Q.tesla ==> ["tesla", "T"]
-  , Q.henry ==> ["henry", "H"]
+  , Q.henry ==> ["henrys","henries","henry", "H"]
   , Q.coulomb ==> ["coulomb", "C"]
   , Q.siemens ==> ["siemens", "S"]
   , Q.lumen ==> ["lumen", "lm"]


### PR DESCRIPTION
The addition of plural units helps with natural flow when writing lines, and the parser entry for Henrys didn't have them yet.