### PR TITLE
Implement 'copy' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,14 @@ Reference
 
 -   Commands
 
-    | Command           | Syntax             |
-    |-------------------|--------------------|
-    | help text         | `help`, `?`        |
-    | list of variables | `list`, `ls`, `ll` |
-    | reset environment | `reset`            |
-    | clear screen      | `clear`, `cls`     |
-    | quit (CLI)        | `quit`, `exit`     |
+    | Command                  | Syntax             |
+    |--------------------------|--------------------|
+    | help text                | `help`, `?`        |
+    | list of variables        | `list`, `ls`, `ll` |
+    | reset environment        | `reset`            |
+    | clear screen             | `clear`, `cls`     |
+    | copy result to clipboard | `copy`, `cp`       |
+    | quit (CLI)               | `quit`, `exit`     |
 
 -   Supported units (remember that you can use tab completion).
 
@@ -268,7 +269,7 @@ Reference
     | [Tablespoon](https://en.wikipedia.org/wiki/Tablespoon)                       | `tablespoons`, `tablespoon`, `tbsp`                                         |
     | [Teaspoon](https://en.wikipedia.org/wiki/Teaspoon)                           | `teaspoons`, `teaspoon`, `tsp`                                              |
     | [Tesla](https://en.wikipedia.org/wiki/Tesla_(unit))                          | `tesla`, `T`                                                                |
-    | [Thou](https://en.wikipedia.org/wiki/Thousandth_of_an_inch)                  | `thou`, `mil`, `mils`                                                       |
+    | [Thou](https://en.wikipedia.org/wiki/Thousandth_of_an_inch)                  | `thou`, `mils`, `mil`                                                       |
     | [Tonne](https://en.wikipedia.org/wiki/Tonne)                                 | `tonnes`, `tonne`, `tons`, `ton`, `t`                                       |
     | [US Dollar](https://en.wikipedia.org/wiki/USD)                               | `dollars`, `dollar`, `USD`, `$`                                             |
     | [Volt](https://en.wikipedia.org/wiki/Volt)                                   | `volts`, `volt`, `V`                                                        |

--- a/docs/reference-syntax.md
+++ b/docs/reference-syntax.md
@@ -22,10 +22,11 @@ Reference
 
   - Commands
 
-    | Command           | Syntax             |
-    | ----------------- | ------------------ |
-    | help text         | `help`, `?`        |
-    | list of variables | `list`, `ls`, `ll` |
-    | reset environment | `reset`            |
-    | clear screen      | `clear`, `cls`     |
-    | quit (CLI)        | `quit`, `exit`     |
+    | Command                  | Syntax             |
+    | ------------------------ | ------------------ |
+    | help text                | `help`, `?`        |
+    | list of variables        | `list`, `ls`, `ll` |
+    | reset environment        | `reset`            |
+    | clear screen             | `clear`, `cls`     |
+    | copy result to clipboard | `copy`, `cp`       |
+    | quit (CLI)               | `quit`, `exit`     |

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ if (interactive) {
   var readline = require('historic-readline');
   var xdgBasedir = require('xdg-basedir');
   var path = require('path');
+  var clipboardy = require('clipboardy');
 
   // Set up REPL
   var rl = readline.createInterface({
@@ -91,6 +92,13 @@ if (interactive) {
             process.exit(0);
           } else if (res.msgType == "clear") {
             process.stdout.write('\x1Bc');
+          } else if (res.msgType == "copy") {
+            if (res.msg == "") {
+              console.log("\nNo result to copy.\n");
+            } else {
+              clipboardy.writeSync(res.msg);
+              console.log("\nCopied result '" + res.msg + "' to clipboard.\n");
+            }
           } else {
             console.log(res.msg + "\n");
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insect",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -127,8 +127,7 @@
     "arch": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==",
-      "dev": true
+      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -910,6 +909,66 @@
         "tiny-emitter": "^2.0.0"
       }
     },
+    "clipboardy": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
+      "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
+      "requires": {
+        "arch": "^2.1.1",
+        "execa": "^1.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        }
+      }
+    },
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -1118,7 +1177,6 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -1415,7 +1473,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -2974,6 +3031,11 @@
         }
       }
     },
+    "is-docker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3087,8 +3149,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -3678,8 +3739,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-static": {
       "version": "0.7.11",
@@ -3977,8 +4037,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -4144,7 +4203,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -4536,8 +4594,7 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "send": {
       "version": "0.16.2",
@@ -4657,7 +4714,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -4665,8 +4721,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shell-quote": {
       "version": "1.6.1",
@@ -4694,8 +4749,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simple-concat": {
       "version": "1.0.1",
@@ -5095,6 +5149,11 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -5525,7 +5584,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "jquery.terminal": "^2.18.0",
     "keyboardevent-key-polyfill": "=1.1.0",
     "line-reader": "^0.4.0",
-    "xdg-basedir": "^2.0.0"
+    "xdg-basedir": "^2.0.0",
+    "clipboardy": "^2.3.0"
   },
   "devDependencies": {
     "fs-extra": "^9.0.1",

--- a/src/Insect.purs
+++ b/src/Insect.purs
@@ -13,10 +13,11 @@ module Insect
 import Prelude
 
 import Data.Either (Either(..))
-import Data.Map (keys)
+import Data.Map (lookup, keys)
 import Data.Set (toUnfoldable)
 
 import Data.Array (sort)
+import Data.Maybe (maybe)
 
 import Text.Parsing.Parser.Pos (Position(..))
 import Text.Parsing.Parser (parseErrorPosition, parseErrorMessage)
@@ -25,10 +26,11 @@ import Insect.Parser (Dictionary(..), (==>),
                       normalUnitDict, imperialUnitDict, parseInsect)
 import Insect.Parser as P
 import Insect.Interpreter (MessageType(..), Message(..), runInsect)
-import Insect.Environment (Environment)
+import Insect.Environment (Environment, StoredValue(..))
 import Insect.Environment as E
 import Insect.Format (Formatter, format)
 import Insect.Format as F
+import Insect.PrettyPrint (prettyQuantity)
 
 -- | List of all supported units
 supportedUnits ∷ Array String
@@ -74,6 +76,14 @@ repl fmt env userInput =
               { msgType: "quit"
               , msg: ""
               , newEnv: ans.newEnv }
+           MCopy →
+             { msgType: "copy"
+             , msg: value
+             , newEnv: ans.newEnv }
+               where
+                 storedQty (StoredValue _ q) = q
+                 maybeStoredValue = lookup "ans" ans.newEnv.values
+                 value = maybe "" (\sv -> format fmtPlain (prettyQuantity $ storedQty sv)) maybeStoredValue
            MClear →
              { msgType: "clear"
              , msg: ""

--- a/src/Insect/Interpreter.purs
+++ b/src/Insect/Interpreter.purs
@@ -41,7 +41,7 @@ type Expect = Either EvalError
 data MessageType = Value | ValueSet | Info | Error
 
 -- | The output type of the interpreter.
-data Message = Message MessageType Markup | MQuit | MClear
+data Message = Message MessageType Markup | MQuit | MCopy | MClear
 
 -- | Check if the numerical value of a quantity is finite, throw a
 -- | `NumericalError` otherwise.
@@ -350,5 +350,7 @@ runInsect env (Command Reset) =
   , newEnv: initialEnvironment }
 
 runInsect env (Command Quit) = { msg: MQuit, newEnv: initialEnvironment }
+
+runInsect env (Command Copy) = { msg: MCopy, newEnv: env }
 
 runInsect env (Command Clear) = { msg: MClear, newEnv: env }

--- a/src/Insect/Language.purs
+++ b/src/Insect/Language.purs
@@ -71,6 +71,7 @@ data Command
  | Reset
  | List
  | Clear
+ | Copy
  | Quit
 
 derive instance eqCommand ∷ Eq Command

--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -53,7 +53,7 @@ identLetter = letter <|> digit <|> char '_' <|> char '\''
 
 -- | A list of allowed commands
 commands ∷ Array String
-commands = ["help", "?", "list", "ls", "ll", "reset", "clear", "cls", "quit", "exit"]
+commands = ["help", "?", "list", "ls", "ll", "reset", "clear", "cls", "quit", "exit", "copy", "cp"]
 
 -- | The language definition.
 insectLanguage ∷ LanguageDef
@@ -478,6 +478,7 @@ command =
     <|> (reserved "list" <|> reserved "ls" <|> reserved "ll") *> pure List
     <|> (reserved "reset") *> pure Reset
     <|> (reserved "clear" <|> reserved "cls") *> pure Clear
+    <|> (reserved "copy" <|> reserved "cp") *> pure Copy
     <|> (reserved "quit" <|> reserved "exit") *> pure Quit
   ) <* eof
 

--- a/web/index.html
+++ b/web/index.html
@@ -71,6 +71,14 @@
           this.clear();
           insectEnv = Insect.initialEnvironment;
           return;
+        } else if (res.msgType == "copy") {
+          // Copy result to clipboard:
+          if (res.msg == "") {
+            res.msg = "\nNo result to copy.\n";
+          } else {
+            navigator.clipboard.writeText(res.msg);
+            res.msg = "\nCopied result '" + res.msg + "' to clipboard.\n";
+          }
         }
 
         if (res.msgType === "error") {


### PR DESCRIPTION
fixes #240 

Provides `copy` command (and `cp` alias) to put the current value of `ans` in the users clipboard.
Tested in FF and natively on X.

Browser support uses built-in `navigator.clipboard`, so will probably only work on (very?) recent browsers.
This can be fixed if necessary at the expense of an external dependency.

The structure of `res.newEnv.values` doesn't appear to be usable in JS, so I have hi-jacked the `msg` field to provide the value to the UI instead. This feels a bit hacky, so alternative suggestions are welcome.
Also, I have no idea what ideomatic purescript should look like... ;-)

Lastly, I have included the changes made by `npm` to my local `package-lock.json` in a separate commit, so that is easy to revert if necessary?