### PR TITLE
Pretty print function definition

### DIFF
--- a/src/Insect/Language.purs
+++ b/src/Insect/Language.purs
@@ -83,6 +83,7 @@ data Statement
  = Expression Expression
  | VariableAssignment Identifier Expression
  | FunctionAssignment Identifier (NonEmpty List Identifier) Expression
+ | PrettyPrintFunction Identifier
  | Command Command
 
 derive instance eqStatement ∷ Eq Statement
@@ -90,4 +91,5 @@ instance showStatement ∷ Show Statement where
   show (Expression e)              = "(Expression " <> show e <> ")"
   show (VariableAssignment i e)    = "(VariableAssignment " <> show i <> " " <> show e <> ")"
   show (FunctionAssignment f xs e) = "(FunctionAssignment " <> show f <> " " <> show xs <> " " <> show e <> ")"
+  show (PrettyPrintFunction f)     = "(PrettyPrintFunction " <> show f <> ")"
   show (Command c)                 = "(Command " <> show c <> ")"

--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -351,7 +351,7 @@ function env = do
       pure name
     else
       case lookup name env.functions of
-        Just (StoredFunction _ fn) → pure name
+        Just (StoredFunction _ fn _) → pure name
         Nothing → fail ("Unknown function '" <> name <> "'")
 
 -- | Parse a full mathematical expression.
@@ -515,6 +515,7 @@ statement ∷ Environment → P Statement
 statement env =
       (Command <$> command)
   <|> assignment env
+  <|> (try (whiteSpace *> (PrettyPrintFunction <$> function env) <* eof))
   <|> (Expression <$> fullExpression env)
 
 -- | Run the Insect-parser on a `String` input.

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -740,6 +740,14 @@ main = runTest do
       shouldFail "meter(x)=2" -- 'meter' is a reserved unit
       shouldFail "list(x)=4" -- 'list' is a reserved keyword
 
+  suite "Parser - Pretty print function" do
+    test "Simple" do
+      allParseAs (PrettyPrintFunction "cos") $
+        [ "cos"
+        , "  cos"
+        , "cos  "
+        ]
+
   let pretty' str =
         case parseInsect initialEnvironment str of
           Right (Expression expr) → format fmtPlain (pretty expr)


### PR DESCRIPTION
This adds a new statement to the Insect language that allows
users to pretty-print a function definition by simply typing
the name of the function:

    >>> f(x, y) = cos(x) + y^2

      f(x, y) = cos(x) + y^2

    >>> f

      f(x, y) = cos(x) + y^2

    >>> cos

      cos(x) = builtin function

    >>> atan2

      atan2(x, y) = builtin function

    >>> mean

      mean(x1, x2, …) = builtin function

closes #251