### PR TITLE
No custom URL parameter replacements

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -141,7 +141,7 @@
         if (location.search) {
           var queryParams = new URLSearchParams(location.search);
           if (queryParams.has("q")) {
-            term.exec(queryParams.get("q").replace(/\+/g, " "));
+            term.exec(queryParams.get("q"));
           }
         }
       });


### PR DESCRIPTION
[`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) already does the encoding/decoding of URL
components for us so there is no need for custom replacements
here.

Fixes #282

FYI: @septatrix