### PR TITLE
Remove `fs-extra` dependency in favor of built-in `fs`

### DIFF
--- a/copy.js
+++ b/copy.js
@@ -1,14 +1,8 @@
-const { copy } = require("fs-extra");
+const { copyFileSync } = require("fs");
 
-async function copyToWeb() {
-  await Promise.all([
-    copy("insect.js", "web/insect.js"),
-    copy("node_modules/keyboardevent-key-polyfill/index.js", "web/keyboardevent-key-polyfill.js"),
-    copy("node_modules/jquery/dist/jquery.min.js", "web/jquery.min.js"),
-    copy("node_modules/jquery.terminal/js/jquery.terminal.min.js", "web/jquery.terminal.min.js"),
-    copy("node_modules/jquery.terminal/js/jquery.mousewheel-min.js", "web/jquery.mousewheel-min.js"),
-    copy("node_modules/jquery.terminal/css/jquery.terminal.min.css", "web/terminal.css"),
-  ])
-}
-
-copyToWeb()
+copyFileSync("insect.js", "web/insect.js");
+copyFileSync("node_modules/keyboardevent-key-polyfill/index.js", "web/keyboardevent-key-polyfill.js");
+copyFileSync("node_modules/jquery/dist/jquery.min.js", "web/jquery.min.js");
+copyFileSync("node_modules/jquery.terminal/js/jquery.terminal.min.js", "web/jquery.terminal.min.js");
+copyFileSync("node_modules/jquery.terminal/js/jquery.mousewheel-min.js", "web/jquery.mousewheel-min.js");
+copyFileSync("node_modules/jquery.terminal/css/jquery.terminal.min.css", "web/terminal.css");

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "insect": "index.js"
       },
       "devDependencies": {
-        "fs-extra": "^10.0.1",
         "live-server": "^1.2.1",
         "npm-run-all": "^4.1.5",
         "psc-package": "^4.0.1",
@@ -2068,20 +2067,6 @@
         "readable-stream": "^2.0.0"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/fs-minipass": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
@@ -3180,18 +3165,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/jsonify": {
       "version": "0.0.0",
@@ -6203,15 +6176,6 @@
         "imurmurhash": "^0.1.4"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/unix-crypt-td-js": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz",
@@ -8246,17 +8210,6 @@
         "readable-stream": "^2.0.0"
       }
     },
-    "fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
     "fs-minipass": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
@@ -9096,16 +9049,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
-      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -11548,12 +11491,6 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
-    },
-    "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true
     },
     "unix-crypt-td-js": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "xdg-basedir": "^4.0.0"
   },
   "devDependencies": {
-    "fs-extra": "^10.0.1",
     "live-server": "^1.2.1",
     "npm-run-all": "^4.1.5",
     "psc-package": "^4.0.1",


### PR DESCRIPTION
The fewer the dependencies, the better.

Tested with `hyperfine` on my machine (YMMV), the `fs` version is
actually faster (114.2 ± 3.8 ms with `fs-extra `vs. 76.3 ± 0.8 ms with
`fs`), but that's not really the point.