### PR TITLE
Fix history not working properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,12 +80,14 @@ function startInsect() {
     // Open the history file for reading and appending.
     var historyFd = fs.openSync(path.join(xdgBasedir.data, "insect-history"), 'a+');
 
+    var maxHistoryLength = 5000;
+
     // Set up REPL
     var rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
-      history: fs.readFileSync(historyFd, "utf8").split("\n").slice(0, -1).reverse(),
-      historySize: 0,
+      history: fs.readFileSync(historyFd, "utf8").split("\n").slice(0, -1).reverse().slice(0, maxHistoryLength),
+      historySize: maxHistoryLength,
       completer: function(line) {
         var identifiers = Insect.identifiers(insectEnv);
 


### PR DESCRIPTION
This is a bug introduced by yours truly in https://github.com/sharkdp/insect/pull/299; in [readline's docs](https://nodejs.org/api/readline.html#readlinepromisescreateinterfaceoptions) is this sentence about `historySize`:

> To disable the history set this value to 0.

My mind read it as this:

> To disable the history **limit** set this value to 0.

I think 5000 is a reasonable limit, especially considering that even if the history file contains more than 5000 items, the additional history items will not be removed from the history file; you will just not be able to go back far enough to get to them in the Insect REPL.