### PR TITLE
Delete `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-npm run browserify
-npm run copy


### PR DESCRIPTION
After I deleted the nexe-related code in build.sh in cad2dc4c7bf74406158f53a153cb9fbca53583d7, the script does pretty much the same thing as `npm run build`, so there's no need for it anymore.
