### PR TITLE
Update to PureScript Quantities v12.0.1

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -11,6 +11,6 @@ in      upstream
               , "decimals"
               ]
             , repo = "https://github.com/sharkdp/purescript-quantities.git"
-            , version = "v10.0.0"
+            , version = "v12.0.1"
             }
         }


### PR DESCRIPTION
I noticed `1 year -> days` returned `365.25` instead of `365.2425`.
Before PureScript Quantities v12.0.0, this was indeed how `year` was defined. That changed after that, with the addition of `julianYear`, which is `365.25`, and `year` is now correctly set to `365.2425`.

Here's an updated list of dependencies with the latest version of PureScript Quantities (v12.0.1). This new version also includes a few other changes (check the changelog for details).
Feel free to correct if I broke something.