### PR TITLE
Refactors, again

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,9 +88,7 @@ async function startInsect() {
         var identifiers = Insect.identifiers(insectEnv);
 
         var keywords =
-          identifiers.concat(Insect.functions(insectEnv))
-                     .concat(Insect.supportedUnits)
-                     .concat(Insect.commands);
+          identifiers.concat(Insect.functions(insectEnv), Insect.supportedUnits, Insect.commands);
 
         var lastWord = line;
         if (line.trim() !== "") {
@@ -115,12 +113,12 @@ async function startInsect() {
       var res = runInsect(Insect.fmtConsole, line);
 
       if (res) {
-        if (res.msgType == "quit") {
+        if (res.msgType === "quit") {
           process.exit(0);
-        } else if (res.msgType == "clear") {
+        } else if (res.msgType === "clear") {
           process.stdout.write('\x1Bc');
-        } else if (res.msgType == "copy") {
-          if (res.msg == "") {
+        } else if (res.msgType === "copy") {
+          if (res.msg === "") {
             console.log("\nNo result to copy.\n");
           } else {
             clipboardy.writeSync(res.msg);

--- a/src/Insect.purs
+++ b/src/Insect.purs
@@ -81,7 +81,7 @@ repl fmt env userInput =
                where
                  storedQty (StoredValue _ q) = q
                  maybeStoredValue = lookup "ans" ans.newEnv.values
-                 value = maybe "" (\sv -> format fmtPlain (prettyQuantity $ storedQty sv)) maybeStoredValue
+                 value = maybe "" (\sv → format fmtPlain (prettyQuantity $ storedQty sv)) maybeStoredValue
            MClear →
              { msgType: "clear"
              , msg: ""

--- a/src/Insect/Format.purs
+++ b/src/Insect/Format.purs
@@ -22,7 +22,6 @@ module Insect.Format
 
 import Prelude
 
-import Data.Array ((:))
 import Data.Foldable (foldMap)
 
 data FormatType
@@ -89,7 +88,7 @@ uncurry fmt (Formatted ot ft s) = fmt ot ft s
 
 -- | Format an output text with a given formatter.
 format ∷ Formatter → Markup → String
-format formatter m = foldMap (uncurry formatter) (optional nl : m)
+format formatter m = foldMap (uncurry formatter) ([ optional nl ] <> m)
 
 -- | Formatter for plain text output on a command line.
 fmtPlain ∷ Formatter

--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -200,7 +200,7 @@ normalUnitDict = Dictionary
   , Q.sievert ==> ["sievert", "Sv"]
   , Q.weber ==> ["weber", "Wb"]
   , Q.tesla ==> ["tesla", "T"]
-  , Q.henry ==> ["henrys","henries","henry", "H"]
+  , Q.henry ==> ["henrys", "henries", "henry", "H"]
   , Q.coulomb ==> ["coulomb", "C"]
   , Q.siemens ==> ["siemens", "S"]
   , Q.lumen ==> ["lumen", "lm"]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -59,8 +59,7 @@ shouldFail input =
 
 expectOutput ∷ Environment → String → String → Aff Unit
 expectOutput env expected inp =
-  let res = repl fmtPlain env inp
-      out = res.msg
+  let { msg: out } = repl fmtPlain env inp
   in
     unless (out == expected) do
       failure $ "Unexpected result:\n" <>

--- a/web/index.html
+++ b/web/index.html
@@ -66,14 +66,14 @@
           // Clear screen:
           this.clear();
           return;
-        } else if (res.msgType == "quit") {
+        } else if (res.msgType === "quit") {
           // Treat as reset:
           this.clear();
           insectEnv = Insect.initialEnvironment;
           return;
-        } else if (res.msgType == "copy") {
+        } else if (res.msgType === "copy") {
           // Copy result to clipboard:
-          if (res.msg == "") {
+          if (res.msg === "") {
             res.msg = "\nNo result to copy.\n";
           } else {
             navigator.clipboard.writeText(res.msg);
@@ -126,9 +126,7 @@
             var identifiers = Insect.identifiers(insectEnv);
 
             var keywords =
-              identifiers.concat(Insect.functions(insectEnv))
-                         .concat(Insect.supportedUnits)
-                         .concat(Insect.commands);
+              identifiers.concat(Insect.functions(insectEnv), Insect.supportedUnits, Insect.commands);
 
             cb(keywords.sort());
           },


### PR DESCRIPTION
- Switched `->` and `::` to their Unicode counterparts, to be consistent with the rest of the codebase
- Use `===` instead of `==`, see https://stackoverflow.com/questions/359494/which-equals-operator-vs-should-be-used-in-javascript-comparisons/359509#359509
- Use `<>` instead of `:` for arrays
- Other minor refactors