### PR TITLE
Add `_` as an alias for `ans`, and disallow assignments to both

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Contents
         constant (`k_B`), gravitational acceleration (`g0`), ideal gas
         constant (`R`), ...
 
-    -   **Last result**: you can use `ans` (answer) to refer to the
-        result of the last calculation.
+    -   **Last result**: you can use `ans` (answer) or `_` to refer to
+        the result of the last calculation.
 
 -   **User-defined functions**:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -79,7 +79,7 @@ Documentation
         Bohr magneton (`µ_B`), Avogadro's constant (`N_A`), Boltzmann constant
         (`k_B`), gravitational acceleration (`g0`), ideal gas constant (`R`), ...
 
-      * **Last result**: you can use `ans` (answer) to refer to the result of the
+      * **Last result**: you can use `ans` (answer) or `_` to refer to the result of the
         last calculation.
 
   - **User-defined functions**:

--- a/src/Insect/Interpreter.purs
+++ b/src/Insect/Interpreter.purs
@@ -252,7 +252,9 @@ runInsect env (Expression e) =
       { msg: Message Value $    (F.optional <$> ([ F.text "  " ] <> pretty e))
                              <> (F.optional <$> [ F.nl, F.nl , F.text "   = " ])
                              <> prettyQuantity value
-      , newEnv: env { values = insert "ans" (StoredValue UserDefined value) env.values }
+      , newEnv:
+          let storedValue = StoredValue UserDefined value
+          in env { values = insert "ans" storedValue (insert "_" storedValue env.values) }
       }
 
 runInsect env (VariableAssignment name val) =

--- a/src/Insect/Parser.purs
+++ b/src/Insect/Parser.purs
@@ -483,19 +483,21 @@ assignment env = do
 
       pure { name, args, expr }
 
-  -- Fail if the name can be parsed as a physical unit
-  failIfUnit name
+  failIfReserved name
 
   case args of
     Nothing → pure (VariableAssignment name expr)
     Just xs → do
-      traverse_ failIfUnit xs
+      traverse_ failIfReserved xs
       pure (FunctionAssignment name xs expr)
 
   where
-    failIfUnit n =
+    failIfReserved n = do
       when (isRight $ runParser n (derivedUnit <* eof)) $
         fail ("'" <> n <> "' is reserved for a physical unit")
+
+      when (n == "_" || n == "ans") $
+        fail ("'" <> n <> "' is a reserved variable name")
 
 -- | Parse a statement in the Insect language.
 statement ∷ Environment → P Statement

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -912,6 +912,13 @@ main = runTest do
       expectOutput' "2500 cm²" "5cm · 5m"
       expectOutput' "0.2 km" "120km/h*6s"
 
+    test "'ans' and '_'" do
+      let env1 = initialEnvironment
+          env2 = (repl fmtPlain env1 "5").newEnv
+          env3 = (repl fmtPlain env2 "_ * 20").newEnv
+
+      expectOutput env3 "1" "ans / 100"
+
     test "Examples" do
       expectOutput' "1080" "1920/16*9"
       expectOutput' "4294967296" "2^32"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -702,6 +702,10 @@ main = runTest do
       shouldFail "exp(1,)"
       shouldFail "exp()"
 
+  -- All of these are reserved units, except '_' and 'ans', which are reserved
+  -- variables that refer to the value of the last evaluated line.
+  let reservedNames = ["m", "meter", "kg", "kilogram", "list", "ans", "_"]
+
   suite "Parser - Variable Assignments" do
     test "Simple" do
       allParseAs (VariableAssignment "xyz_123" (scalar 1.0))
@@ -718,9 +722,7 @@ main = runTest do
       shouldFail "x=3+"
 
     test "Reserved names" do
-      shouldFail "m=2" -- 'm' is reserved unit
-      shouldFail "meter=2" -- 'meter' is a reserved unit
-      shouldFail "list=4" -- 'list' is a reserved keyword
+      for_ reservedNames \name -> shouldFail (name <> "=2")
 
   suite "Parser - Function Assignments" do
     test "Simple" do
@@ -742,9 +744,7 @@ main = runTest do
         ]
 
     test "Reserved names" do
-      shouldFail "m(x)=2" -- 'm' is reserved unit
-      shouldFail "meter(x)=2" -- 'meter' is a reserved unit
-      shouldFail "list(x)=4" -- 'list' is a reserved keyword
+      for_ reservedNames \name -> shouldFail (name <> "(x)=2")
 
   suite "Parser - Pretty print function" do
     test "Simple" do


### PR DESCRIPTION
Fixes #159.

If you want me to pull out the the commit that disallows assignment to `ans` and `_` to a separate PR, I'm okay with that.