### PR TITLE
Fix running `index.cjs` and check that it works successfully in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build Insect
         run: npm run build
 
+      - name: Check that index.cjs runs successfully
+        run: ./index.cjs '1 + 1'
+
       - name: Run tests
         run: npm test
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "clipboardy": "^2.3.0",
-        "decimal.js": "^10.3.1",
+        "decimal.js": "10.3.1",
         "jquery.terminal": "^2.18.0",
         "keyboardevent-key-polyfill": "=1.1.0",
         "line-reader": "^0.4.0",
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -7019,9 +7019,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "decode-uri-component": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "clipboardy": "^2.3.0",
-    "decimal.js": "^10.3.1",
+    "decimal.js": "10.3.1",
     "jquery.terminal": "^2.18.0",
     "keyboardevent-key-polyfill": "=1.1.0",
     "line-reader": "^0.4.0",


### PR DESCRIPTION
Some change in decimal.js 10.4.0 (almost certainly https://github.com/MikeMcl/decimal.js/commit/0bc3fdbdaa5e8d2f58087a8fceb200da28fa6d5c) broke running `index.cjs`. Previously, the CommonJS `decimal.js` module was imported, but with decimal.js 10.4.0 `decimal.mjs` is instead imported, thus the following error when running `index.cjs`:

```
node:internal/modules/cjs/loader:1041
    throw new ERR_REQUIRE_ESM(filename, true);
    ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /home/triallax/Desktop/insect/node_modules/decimal.js/decimal.mjs not supported.
Instead change the require of /home/triallax/Desktop/insect/node_modules/decimal.js/decimal.mjs to a dynamic import() which is available in all CommonJS modules.
    at /home/triallax/Desktop/insect/index.cjs:4:42947
    at Object.<anonymous> (/home/triallax/Desktop/insect/index.cjs:15:331) {
  code: 'ERR_REQUIRE_ESM'
}
```

This PR also adds a step in the CI that runs `./index.cjs`, to ensure a situation like this doesn't happen again in the future.
