### PR TITLE
Add hidden values for sub-one range (milli, micro, etc.)

### DIFF
--- a/src/Insect/Environment.purs
+++ b/src/Insect/Environment.purs
@@ -90,19 +90,20 @@ initialEnvironment =
         , constVal "R"                  Q.idealGasConstant
 
         -- Hidden constants
-        , hiddenVal "atto"        (Q.scalar 1.0e-18)
-        , hiddenVal "femto"       (Q.scalar 1.0e-15)
-        , hiddenVal "pico"        (Q.scalar 1.0e-12)
-        , hiddenVal "nano"        (Q.scalar 1.0e-9)
-        , hiddenVal "micro"       (Q.scalar 1.0e-6)
-        , hiddenVal "milli"       (Q.scalar 1.0e-3)
-        , hiddenVal "hundred"     (Q.scalar 1.0e2)
-        , hiddenVal "thousand"    (Q.scalar 1.0e3)
-        , hiddenVal "million"     (Q.scalar 1.0e6)
-        , hiddenVal "billion"     (Q.scalar 1.0e9)
-        , hiddenVal "trillion"    (Q.scalar 1.0e12)
-        , hiddenVal "quadrillion" (Q.scalar 1.0e15)
-        , hiddenVal "quintillion" (Q.scalar 1.0e18)
+        , hiddenVal "quintillionth" (Q.scalar 1.0e-18)
+        , hiddenVal "quadrillionth" (Q.scalar 1.0e-15)
+        , hiddenVal "trillionth"    (Q.scalar 1.0e-12)
+        , hiddenVal "billionth"     (Q.scalar 1.0e-9)
+        , hiddenVal "millionth"     (Q.scalar 1.0e-6)
+        , hiddenVal "thousandth"    (Q.scalar 1.0e-3)
+        , hiddenVal "hundredth"     (Q.scalar 1.0e-2)
+        , hiddenVal "hundred"       (Q.scalar 1.0e2)
+        , hiddenVal "thousand"      (Q.scalar 1.0e3)
+        , hiddenVal "million"       (Q.scalar 1.0e6)
+        , hiddenVal "billion"       (Q.scalar 1.0e9)
+        , hiddenVal "trillion"      (Q.scalar 1.0e12)
+        , hiddenVal "quadrillion"   (Q.scalar 1.0e15)
+        , hiddenVal "quintillion"   (Q.scalar 1.0e18)
 
         , hiddenVal "googol"      (Q.scalar 1.0e100)
 

--- a/src/Insect/Environment.purs
+++ b/src/Insect/Environment.purs
@@ -90,6 +90,12 @@ initialEnvironment =
         , constVal "R"                  Q.idealGasConstant
 
         -- Hidden constants
+        , hiddenVal "atto"        (Q.scalar 1.0e-18)
+        , hiddenVal "femto"       (Q.scalar 1.0e-15)
+        , hiddenVal "pico"        (Q.scalar 1.0e-12)
+        , hiddenVal "nano"        (Q.scalar 1.0e-9)
+        , hiddenVal "micro"       (Q.scalar 1.0e-6)
+        , hiddenVal "milli"       (Q.scalar 1.0e-3)
         , hiddenVal "hundred"     (Q.scalar 1.0e2)
         , hiddenVal "thousand"    (Q.scalar 1.0e3)
         , hiddenVal "million"     (Q.scalar 1.0e6)


### PR DESCRIPTION
This pull request adds support for smaller scale prefixes (i.e., values less than 1) in the Insect calculator by including hidden values for milli, micro, nano, pico, femto, atto, zepto, and yocto.

### Before 
Up to now, only the specification of milli etc. in connection with a unit was supported.

<img width="908" alt="image" src="https://user-images.githubusercontent.com/113907719/227767428-b8774476-6743-437b-8175-cf9a81744a18.png">

### Now

With this changes, smaller numbers no longer have to be written out with zeros (Analogous to the support of positive powers of ten).

<img width="908" alt="image" src="https://user-images.githubusercontent.com/113907719/227767502-83866d2f-a229-4def-a43f-d0580ea0262a.png">
