### PR TITLE
Support converting quantity to base units

### DIFF
--- a/src/Insect/Interpreter.purs
+++ b/src/Insect/Interpreter.purs
@@ -111,8 +111,11 @@ eval env (Apply name xs)        =
         Nothing → Left (LookupError name)
 eval env (BinOp op x y)         = do
   x' <- eval env x
-  y' <- eval env y
-  run op x' y' >>= checkFinite
+  if op == ConvertTo && y == Variable "base" then
+    checkFinite (Q.toStandard x')
+  else do
+    y' <- eval env y
+    run op x' y' >>= checkFinite
   where
     run ∷ BinOp → Quantity → Quantity → Expect Quantity
     run Sub       a b = qSubtract a b

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -913,6 +913,10 @@ main = runTest do
       expectOutput' "500 m·cm" "5m^2 -> m*cm"
       expectOutput' "500 cm·m" "5m^2 -> cm*m"
       expectOutput' "0.1 MB/s" "1 kB / 10 ms -> MB/s"
+      expectOutput' "0.1 m" "0.1 m -> base"
+      expectOutput' "0.01 m" "1 cm -> base"
+      expectOutput' "1 m²·g/(s³·A)" "1 mV -> base"
+      expectOutput' "1000 m²·g/(s³·A)" "1 J/C -> base"
 
     test "Implicit multiplication" do
       let myEnv =


### PR DESCRIPTION
Fixes #184.

To be honest, this is very much not how I want this to be implemented. I was thinking about adding something like `Base` to the `Expression` datatype, but since `base` in `-> base` isn't a unit per se but a part of the language's syntax, it can't be cleanly added to `Expression` currently. This also introduces the issue of how to handle conversion to a `base` variable:

```
>>> base = 2m

  base = 2 m

>>> 5 V -> base

  5 V ➞ base

   = 5000 m²·g/(s³·A)
```

If we choose to use this (terrible IMO) implementation, should `base` be allowed as a variable name? If so, how do we allow conversions to it? With something like `-> (base)` perhaps? (the parser, or maybe something else, currently seems to fold expressions in parentheses, so this will also need some changes there)

Alternatively, we may want to special-case `-> base` in the parser into something like `ConvertToBase`.

I'd love to hear your thoughts about how to best implement this (if at all) @sharkdp.
