### PR TITLE
Move from test-unit to spec

### DIFF
--- a/test.dhall
+++ b/test.dhall
@@ -1,5 +1,5 @@
 let conf = ./spago.dhall
 in conf // {
   sources = conf.sources # [ "test/**/*.purs" ]
-, dependencies = conf.dependencies # ["aff", "effect", "test-unit"]
+, dependencies = conf.dependencies # ["aff", "effect", "spec"]
 }


### PR DESCRIPTION
The migration is rather straightforward, but it brings a HUGE decrease in the time required to run tests as determined by `hyperfine --warmup 2 'npm test'`. Before:
```
Benchmark 1: npm test
  Time (mean ± σ):     71.245 s ±  0.619 s    [User: 75.323 s, System: 0.868 s]
  Range (min … max):   70.245 s … 72.363 s    10 runs
```
After:
```
Benchmark 1: npm test
  Time (mean ± σ):     18.666 s ±  0.256 s    [User: 22.082 s, System: 0.671 s]
  Range (min … max):   18.327 s … 19.048 s    10 runs
```

I'm also considering moving to assert instead, but it's much lower-level than the other two, so I'm not too sure about that. It could be worth a try though.